### PR TITLE
Adding link-only channel option

### DIFF
--- a/plugins/utils/constants.py
+++ b/plugins/utils/constants.py
@@ -6,6 +6,9 @@ class Constants(object):
     def url_output_channel():
         return "url_output_channel"
     @property
+    def linkonly_channel():
+        return "linkonly_channel"
+    @property
     def adminonlycontrol():
         return "admin_only"
     @property

--- a/plugins/utils/migrationhelper.py
+++ b/plugins/utils/migrationhelper.py
@@ -1,6 +1,5 @@
-import jsonstorage
-from constants import Constants
-
+from utils.constants import Constants
+import utils.jsonstorage as jsonstorage
 
 REQUIRED_VERSION = 1 
 
@@ -14,7 +13,7 @@ class MigrationHelper:
 
     def check_for_updates(self):
         while self.current_version < REQUIRED_VERSION:
-            print "update from {} to {}".format(self.current_version, REQUIRED_VERSION)
+            print ("update from {} to {}".format(self.current_version, REQUIRED_VERSION))
             self.current_version += 1
             if self.current_version == 1:
                 self.update_one()

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-
-python -m disco.cli --config config.json
+PYTHONPATH="$PYTHONPATH:./plugins/" python3 -m disco.cli --config config.json


### PR DESCRIPTION
The link-only channel is a channel where the bot will delete any messages that do not include a link.
Moderator messages should be excluded.
Requires python3 and a new dependency: nest_asyncio.